### PR TITLE
add hide_parameters to _create_engine for async and sync databases

### DIFF
--- a/ash_dal/database/async_database.py
+++ b/ash_dal/database/async_database.py
@@ -73,13 +73,14 @@ class AsyncDatabase:
         return self.session_maker()  # pyright: ignore [ reportOptionalCall ]
 
     @staticmethod
-    def _create_engine(url: URL, ssl_context: ssl.SSLContext | None) -> AsyncEngine:
+    def _create_engine(url: URL, ssl_context: ssl.SSLContext | None, hide_parameters: bool = True) -> AsyncEngine:
         connect_args = {"ssl": ssl_context} if ssl_context else {}
         try:
             engine = create_async_engine(
                 url,
                 connect_args=connect_args,
                 pool_pre_ping=True,
+                hide_parameters=hide_parameters,
             )
             return engine
         except Exception as ex:

--- a/ash_dal/database/sync_database.py
+++ b/ash_dal/database/sync_database.py
@@ -70,13 +70,14 @@ class Database:
         return self.session_maker()  # pyright: ignore [ reportOptionalCall ]
 
     @staticmethod
-    def _create_engine(url: URL, ssl_context: ssl.SSLContext | None) -> Engine:
+    def _create_engine(url: URL, ssl_context: ssl.SSLContext | None, hide_parameters: bool = True) -> Engine:
         connect_args = {"ssl": ssl_context} if ssl_context else {}
         try:
             engine = create_engine(
                 url,
                 connect_args=connect_args,
                 pool_pre_ping=True,
+                hide_parameters=hide_parameters,
             )
             return engine
         except Exception as ex:


### PR DESCRIPTION
## Change Summary

To avoid PHI in sqlalchemy stack trace parameters, set `hide_parameters` by default

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactor (changes code structure with same or similar functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
